### PR TITLE
#18: Default background, add checks

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/extra_configures/bmz_image_handler_conf.php
+++ b/1_Installation_Files (v1.5.5)/includes/extra_configures/bmz_image_handler_conf.php
@@ -10,7 +10,7 @@
  * @version $Id: bmz_image_handler_conf.php,v 2.0 Rev 8 2010-05-31 23:46:5 DerManoMann Exp $
  * Last modified by DerManoMann 2010-05-31 23:46:50 
  */
-
+$ihConf = array();
 $ihConf['noresize_key']         = 'noresize';         //files which contain this string will not be resized
 $ihConf['noresize_dirs']        = array('noresize', 'banners'); //images in directories with these names within the images directory will not be resized.
 $ihConf['trans_threshold']      = '90%';              //this is where semitransparent pixels blend to transparent when rendering gifs with ImageMagick


### PR DESCRIPTION
If a background configuration is missing, use the default defined in the
$ihConf array.  Then validate all backgrounds to make sure that they're
acceptable, defaulting to `transparent 255:255:255` if not.