### PR TITLE
Update Zen Cart support thread link in readme.

### DIFF
--- a/readme/image_handler_readme.html
+++ b/readme/image_handler_readme.html
@@ -21,9 +21,7 @@
 <h2>Image Handler<sup>5</sup> for Zen Cart versions 1.5.5 and later</h2>
 
 
-<p>Support thread: <a href="https://www.zen-cart.com/forum/showthread.php?t=194740" target="_blank">https://www.zen-cart.com/forum/showthread.php?t=194740</a><br>
-Download link: <a href="https://www.zen-cart.com/index.php?main_page=product_contrib_info&amp;products_id=2098" target="_blank">https://www.zen-cart.com/index.php?main_page=product_contrib_info&amp;products_id=2098</a></p>
-
+<p>Support thread: <a href="https://www.zen-cart.com/showthread.php?222983-Image-Handler-5-(for-v1-5-5)-Support-Thread" target="_blank">https://www.zen-cart.com/showthread.php?222983-Image-Handler-5-(for-v1-5-5)-Support-Thread</a></p>
 
 <div id="slidetabsmenu" style="display: none;">
 <ul>


### PR DESCRIPTION
... to the newly-created one.  Remove the download link; otherwise, it's
a chicken/egg thing because the plugin will need to be released before
the download link is known.