### PR TITLE
#70, #73: Various updates and re-factoring

### DIFF
--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/classes/ImageHandlerAdmin.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/classes/ImageHandlerAdmin.php
@@ -3,8 +3,17 @@
 // Part of the "Image Handler" plugin, v5.0.0 and later, by Cindy Merkin a.k.a. lat9 (cindy@vinosdefrutastropicales.com)
 // Copyright (c) 2017 Vinos de Frutas Tropicales
 //
+if (!defined('IH_DEBUG')) {
+    define('IH_DEBUG', 'true'); //-Either 'true' or 'false'
+}
 class ImageHandlerAdmin
 {
+    public function __construct()
+    {
+        $this->debug = (IH_DEBUG == 'true');
+        $this->debugLogfile = DIR_FS_LOGS . '/ih_debug.log';
+    }
+    
     public function getImageDetailsString($filename) 
     {
         if (!file_exists($filename)) {
@@ -20,38 +29,72 @@ class ImageHandlerAdmin
         return $str;
     }
     
+    // -----
+    // Search the directory specified for matching additional images, presumed to be a sub-directory
+    // off the images root directory.
     //
-    // Search the base directory and find additional images
+    // Note that Zen Cart's additional-images "matching" depends on whether the images are present
+    // in the image-root ($directory is '') or in an actual subdirectory (non-blank $directory).
     //
-    public function findAdditionalImages(&$array, $directory, $extension, $base ) 
+    // When in the root, **any** matching suffix for the main-image's name results in a matching
+    // additional image (e.g. my_image.jpg matches my_images.jpg, my_images-1.jpg) while the
+    // matching suffix for sub-directory images **must** have an underscore (_) separating the names,
+    // e.g. my_image.jpg matches my_image_01.jpg, my_image_01_02_03.jpg ... but does not match
+    // my_images.jpg or my_images-1.jpg).
+    //
+    // The function returns a simple, sorted array containing the matching filenames (without the
+    // directory information).
+    //
+    public function findAdditionalImages(&$array, $directory, $extension, $base) 
     {
-        $image = $base . $extension;
-
-        // Check for additional matching images
-        if ($dir = @dir($directory)) {
-            while ($file = $dir->read()) {
-                if (!is_dir($directory . $file)) {
-                    if (preg_match("/^" . $base . "/i", $file) == '1') {
-                         //error_log( "BASE: ".$base.' FILE: '.$file.PHP_EOL);
-                        if (substr($file, 0, strrpos($file, '.')) != substr($image, 0, strrpos($image, '.'))) {
-                            if ($base . preg_replace("/^$base/", '', $file) == $file) {
-                                $array[] = $file;
-                                 //error_log( "\tI AM A MATCH " . $directory . '/'.$file . $extension .PHP_EOL);
-                            } else {
-                                 //error_log( "\tI AM NOT A MATCH" . $file . PHP_EOL);
-                            } 
-                        }
-                    }
-                }
+        // -----
+        // Set up the to-be-matched image name, depending on whether the search is being
+        // performed in the root or a sub-directory. For the root, any matching characters after the 
+        // main-image name; for a sub-directory, 0 (for the main-image) or 1 (for any additional)
+        // matches on _{something}.
+        //
+        $image_match = ($directory == '') ? '.*' : '(?:_.*)?';
+        
+        // -----
+        // Determine whether the directory specified is, in fact, an images sub-directory.  If
+        // not, no files will be returned.
+        //
+        $error = false;
+        try {
+            $image_dir = new DirectoryIterator(DIR_FS_CATALOG . DIR_WS_IMAGES . $directory);
+        } catch(Exception $e) {
+            $error = true;
+            $this->debugLog("findAdditionalImages(array, $directory, $extension, $base), could not iterate directory." . $e->getMessage());
+        }
+        
+        // -----
+        // If the requested directory was accessed without error, find those images!
+        //
+        if (!$error) {
+            // -----
+            // The quotemeta function properly escapes any "regex" special characters that
+            // might be present in either the image's base name or file extension, e.g. '.jpg'
+            // will be converted to '\.jpg'.
+            //
+            $filename_match = quotemeta($base) . $image_match . quotemeta($extension);
+            
+            // -----
+            // Now, do a regex search of the specified directory, looking for matches on the
+            // base-image's name with the additional-image modifier.
+            //
+            $img_files = new RegexIterator($image_dir, '/^' . $filename_match . '$/i', RegexIterator::GET_MATCH);
+            foreach ($img_files as $i => $image_array) {
+                $array[] = $image_array[0];
             }
+            
+            // -----
+            // If there are elements in the array of images, sort them!
+            //
             if (count($array) > 1) {
                 sort($array);
             }
-            $dir->close();
-          
-            return 1;
         }
-        return 0;
+        return ($error) ? 0 : 1;
     }
     
     public function getImportInfo() 
@@ -120,8 +163,9 @@ class ImageHandlerAdmin
         return false;
     }
     
-    public function ihLog ($message, $message_type = 'general') {
-
+    public function debugLog($message) {
+        if ($this->debug) {
+            error_log(PHP_EOL . date('Y-m-d H:i:s: ') . $message . PHP_EOL, 3, $this->debugLogfile);
+        }
     }
-
 }

--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
@@ -7,7 +7,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-define('IH_CURRENT_VERSION', '5.0.1-beta1');
+define('IH_CURRENT_VERSION', '5.0.1-beta2');
 
 // -----
 // Wait until an admin is logged in before seeing if any initialization steps need to be performed.

--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/languages/english/image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/languages/english/image_handler.php
@@ -81,7 +81,7 @@ define('TEXT_MSG_AUTO_BASE_ERROR', 'Automatic base select without default file.'
 define('TEXT_MSG_INVALID_BASE_ERROR', 'Invalid image base name, or unable to find default image.');
 define('TEXT_MSG_AUTO_REPLACE',  'Automatically replacing bad characters in base name, new name: ');
 define('TEXT_MSG_INVALID_SUFFIX', 'Invalid image suffix.');
-define('TEXT_MSG_IMAGE_TYPES_NOT_SAME_ERROR', 'Image types are not the same.');
+define('TEXT_MSG_IMAGE_TYPES_NOT_SAME_ERROR', 'Image types are not the same; image <b>not</b> uploaded.');
 define('TEXT_MSG_DEFAULT_REQUIRED_FOR_RESIZE', 'A default image is required for automatic resizing.');
 define('TEXT_MSG_NO_DEFAULT', 'No default image has been specified.');
 define('TEXT_MSG_FILE_EXISTS', 'File exists! Please alter the base name or suffix.');
@@ -92,6 +92,7 @@ define('TEXT_MSG_NOCREATE_LARGE_IMAGE_DIR', "Unable to create large image direct
 define('TEXT_MSG_NOPERMS_IMAGE_DIR', "Unable to set the permissions of the image directory.");
 define('TEXT_MSG_NOPERMS_MEDIUM_IMAGE_DIR', "Unable to set the permissions of the medium image directory.");
 define('TEXT_MSG_NOPERMS_LARGE_IMAGE_DIR', "Unable to set the permissions of the large image directory.");
+define('TEXT_MSG_NAME_TOO_LONG_ERROR', 'The image file "%1$s" is too long to be saved in the database.  Choose a name that is %2$u characters or fewer.');
 
 define('TEXT_MSG_NOUPLOAD_DEFAULT', "Unable to upload default image file.");
 define('TEXT_MSG_NORESIZE', "Unable to resize image");


### PR DESCRIPTION
image_handler.php updated for #70; the uninstall option is no longer
displayed if the admin doesn't have access.

Other changes: Update the image-upload handling to supply a list of
"acceptable" file extensions, check that the to-be-updated image name
actually "fits" into the database field, using "pathinfo" to gather the
directory/name/extension information for images.

When searching for additional images, use the storefront algorithm (the
match-parameters are different if the file is in the root /images
extension instead of a subdirectory).