### PR TITLE
#98: Align module with zc156

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
+++ b/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
@@ -45,11 +45,6 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     if ($dir = @dir($products_image_directory)) {
         while ($file = $dir->read()) {
             if (!is_dir($products_image_directory . $file)) {
-                
-//-bof-image_handler-lat9  *** 1 of 4 ***
-//                if (substr($file, strrpos($file, '.')) == $file_extension) {
-//                    if(preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
-//                        if ($file != $products_image) {
                 // -----
                 // Some additional-image-display plugins (like Fual Slimbox) have some additional checks to see
                 // if the file is "valid"; this notifier "accomodates" that processing, providing these parameters:
@@ -71,7 +66,6 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
                 if ($current_image_match || substr($file, strrpos($file, '.')) == $file_extension) {
                     if ($current_image_match || preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
                         if ($current_image_match || $file != $products_image) {
-//-eof-image_handler-lat9  *** 1 of 4 ***
                             if ($products_image_base . str_replace($products_image_base, '', $file) == $file) {
                                 //  echo 'I AM A MATCH ' . $file . '<br>';
                                 $images_array[] = $file;
@@ -111,7 +105,6 @@ if ($num_images > 0) {
         $file = $images_array[$i];
         $products_image_large = str_replace(DIR_WS_IMAGES, DIR_WS_IMAGES . 'large/', $products_image_directory) . str_replace($products_image_extension, '', $file) . IMAGE_SUFFIX_LARGE . $products_image_extension;
 
-//-bof-image_handler-lat9  *** 2 of 4 ***
         // -----
         // This notifier lets any image-handler know the current image being processed, providing the following parameters:
         //
@@ -119,7 +112,6 @@ if ($num_images > 0) {
         // $p2 ... (r/w) ... The (possibly updated) filename (including path) of the current additional image.
         //
         $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
-//-eof-image_handler-lat9  *** 2 of 4 ***
 
         $flag_has_large = file_exists($products_image_large);
         $products_image_large = ($flag_has_large ? $products_image_large : $products_image_directory . $file);
@@ -127,7 +119,6 @@ if ($num_images > 0) {
         $base_image = $products_image_directory . $file;
         $thumb_slashes = zen_image(addslashes($base_image), addslashes($products_name), SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
         
-//-bof-image_handler-lat9  *** 3 of 4 ***
         // -----
         // This notifier lets any image-handler "massage" the name of the current thumbnail image name (with appropriate
         // slashes for javascript/jQuery display):
@@ -136,37 +127,39 @@ if ($num_images > 0) {
         // $p2 ... (r/w) ... A reference to the "slashed" thumbnail image name.
         //
         $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_THUMB_SLASHES', array(), $thumb_slashes);
-//-eof-image_handler-lat9  *** 3 of 4 ***
 
         $thumb_regular = zen_image($base_image, $products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
         $large_link = zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large);
 
         // Link Preparation:
-//-bof-image_handler-lat9  *** 4 of 4 ***
         // -----
         // This notifier gives notice that an additional image's script link is requested.  A monitoring observer sets
         // the $p2 value to boolean true if it has provided an alternate form of that link; otherwise, the base code will
         // create that value.
         //
-        // $p1 ... (r/o) ... An associative array, containing the 'flag_display_large', 'products_name', 'products_image_large' and 'thumb_slashes' values.
+        // $p1 ... (r/o) ... An associative array, containing the 'flag_display_large', 'products_name', 'products_image_large', 'thumb_slashes' and current 'index' values.
         // $p2 ... (r/w) ... A reference to the $script_link value, set here to boolean false; if an observer modifies that value, the
         //                     this module's processing is bypassed.
+        // $p3 ... (r/w) ... A reference to the $link_parameters value, which defines the parameters associated with the above
+        //                     link's display.  If the $script_link is updated, these parameters will be used for the display.
         //
         $script_link = false;
+        $link_parameters = 'class="additionalImages centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"';
         $zco_notifier->notify(
             'NOTIFY_MODULES_ADDITIONAL_IMAGES_SCRIPT_LINK',
             array(
                 'flag_display_large' => $flag_display_large,
                 'products_name' => $products_name,
                 'products_image_large' => $products_image_large,
-                'thumb_slashes' => $thumb_slashes
+                'thumb_slashes' => $thumb_slashes,
+                'index' => $i
             ),
-            $script_link
+            $script_link,
+            $link_parameters
         );
         if ($script_link === false) {
             $script_link = '<script type="text/javascript"><!--' . "\n" . 'document.write(\'' . ($flag_display_large ? '<a href="javascript:popupWindow(\\\'' . str_replace($products_image_large, urlencode(addslashes($products_image_large)), $large_link) . '\\\')">' . $thumb_slashes . '<br />' . TEXT_CLICK_TO_ENLARGE . '</a>' : $thumb_slashes) . '\');' . "\n" . '//--></script>';
         }
-//-eof-image_handler-lat9  *** 4 of 4 ***
 
         $noscript_link = '<noscript>' . ($flag_display_large ? '<a href="' . zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large) . '" target="_blank">' . $thumb_regular . '<br /><span class="imgLinkAdditional">' . TEXT_CLICK_TO_ENLARGE . '</span></a>' : $thumb_regular ) . '</noscript>';
 
@@ -177,7 +170,7 @@ if ($num_images > 0) {
 
         // List Box array generation:
         $list_box_contents[$row][$col] = array(
-            'params' => 'class="additionalImages centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"',
+            'params' => $link_parameters,
              'text' => "\n      " . $link
         );
         $col++;


### PR DESCRIPTION
Update the template-specific module to contain the notifier updates
currently present for Zen Cart 156.  Note that this change also removes
the IH-specific bof/eof comments.