### PR TITLE
#100: additional-/main-product-image module updates

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
+++ b/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
@@ -13,7 +13,7 @@
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_START');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_START');
 
 if (!defined('IMAGE_ADDITIONAL_DISPLAY_LINK_EVEN_WHEN_NO_LARGE')) define('IMAGE_ADDITIONAL_DISPLAY_LINK_EVEN_WHEN_NO_LARGE','Yes');
 $images_array = array();
@@ -47,13 +47,13 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
             if (!is_dir($products_image_directory . $file)) {
                 // -----
                 // Some additional-image-display plugins (like Fual Slimbox) have some additional checks to see
-                // if the file is "valid"; this notifier "accomodates" that processing, providing these parameters:
+                // if the file is "valid"; this notifier "accommodates" that processing, providing these parameters:
                 //
                 // $p1 ... (r/o) ... An array containing the variables identifying the current image.
                 // $p2 ... (r/w) ... A boolean indicator, set to true by any observer to note that the image is "acceptable".
                 //
                 $current_image_match = false;
-                $zco_notifier->notify(
+                $GLOBALS['zco_notifier']->notify(
                     'NOTIFY_MODULES_ADDITIONAL_IMAGES_FILE_MATCH',
                     array(
                         'file' => $file,
@@ -64,7 +64,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
                     $current_image_match
                 );
                 if ($current_image_match || substr($file, strrpos($file, '.')) == $file_extension) {
-                    if ($current_image_match || preg_match('/\Q' . $products_image_base . '\E/i', $file) == 1) {
+                    if ($current_image_match || preg_match('/' . preg_quote($products_image_base, '/') . '/i', $file) == 1) {
                         if ($current_image_match || $file != $products_image) {
                             if ($products_image_base . str_replace($products_image_base, '', $file) == $file) {
                                 //  echo 'I AM A MATCH ' . $file . '<br>';
@@ -84,7 +84,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     }
 }
 
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', NULL, $images_array);
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', NULL, $images_array);
 
 
 // Build output based on images found
@@ -111,7 +111,7 @@ if ($num_images > 0) {
         // $p1 ... (r/o) ... The current product's name
         // $p2 ... (r/w) ... The (possibly updated) filename (including path) of the current additional image.
         //
-        $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
+        $GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
 
         $flag_has_large = file_exists($products_image_large);
         $products_image_large = ($flag_has_large ? $products_image_large : $products_image_directory . $file);
@@ -126,7 +126,7 @@ if ($num_images > 0) {
         // $p1 ... (n/a) ... An empty array, not applicable.
         // $p2 ... (r/w) ... A reference to the "slashed" thumbnail image name.
         //
-        $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_THUMB_SLASHES', array(), $thumb_slashes);
+        $GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_THUMB_SLASHES', array(), $thumb_slashes);
 
         $thumb_regular = zen_image($base_image, $products_name, SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT);
         $large_link = zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large);
@@ -145,7 +145,7 @@ if ($num_images > 0) {
         //
         $script_link = false;
         $link_parameters = 'class="additionalImages centeredContent back"' . ' ' . 'style="width:' . $col_width . '%;"';
-        $zco_notifier->notify(
+        $GLOBALS['zco_notifier']->notify(
             'NOTIFY_MODULES_ADDITIONAL_IMAGES_SCRIPT_LINK',
             array(
                 'flag_display_large' => $flag_display_large,
@@ -181,4 +181,4 @@ if ($num_images > 0) {
     } // end for loop
 } // endif
 
-$zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_END');
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_END');

--- a/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/main_product_image.php
+++ b/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/main_product_image.php
@@ -12,19 +12,16 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-//-bof-image_handler-lat9  *** 1 of 3 ***
 // -----
 // This notifier lets an observer know that the module has begun its processing.
 //
-$zco_notifier->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_START');
-//-eof-image_handler-lat9  *** 1 of 3 ***
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_START');
 
 $products_image_extension = substr($products_image, strrpos($products_image, '.'));
 $products_image_base = str_replace($products_image_extension, '', $products_image);
 $products_image_medium = $products_image_base . IMAGE_SUFFIX_MEDIUM . $products_image_extension;
 $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_image_extension;
 
-//-bof-image_handler-lat9  *** 2 of 3 ***
 // -----
 // This notifier lets an image-handling observer know that it's time to determine the image information,
 // providing the following parameters:
@@ -40,7 +37,7 @@ $products_image_large = $products_image_base . IMAGE_SUFFIX_LARGE . $products_im
 // other values have been updated for separate handling.
 //
 $main_image_handled = false;
-$zco_notifier->notify(
+$GLOBALS['zco_notifier']->notify(
     'NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_FILENAME',
     $products_image,
     $main_image_handled,
@@ -51,8 +48,6 @@ $zco_notifier->notify(
 );
 
 if ($main_image_handled !== true) {
-//-eof-image_handler-lat9  *** 2 of 3 ***
-
     // check for a medium image else use small
     if (!file_exists(DIR_WS_IMAGES . 'medium/' . $products_image_medium)) {
         $products_image_medium = DIR_WS_IMAGES . $products_image;
@@ -77,9 +72,6 @@ if ($main_image_handled !== true) {
     'Large ' . $products_image_large . '<br><br>';
     */
     // to be built into a single variable string
-    
-//-bof-image_handler-lat9  *** 3 of 3 ***
 }
 
-$zco_notifier->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_END');
-//-eof-image_handler-lat9  *** 3 of 3 ***
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_MAIN_PRODUCT_IMAGE_END');

--- a/readme/image_handler_readme.html
+++ b/readme/image_handler_readme.html
@@ -110,8 +110,8 @@
                         <legend>Before You Install &hellip; </legend>
                         <p>Starting with v5.0.0, Image Handler<sup>5</sup> no longer requires <em>core-file</em> overwrites, but there are two (2) template-override files required:</p>
                         <ol>
-                            <li>/includes/modules/YOUR_TEMPLATE/additional_images.php <span class="smaller">(4 marked change-sections)</span></li>
-                            <li>/includes/modules/YOUR_TEMPLATE/main_product_image.php <span class="smaller">(3 marked change-sections)</span></li>
+                            <li>/includes/modules/YOUR_TEMPLATE/additional_images.php <span class="smaller">(4 change-sections)</span></li>
+                            <li>/includes/modules/YOUR_TEMPLATE/main_product_image.php <span class="smaller">(3 change-sections)</span></li>
                         </ol>
                         <p><strong>Note:</strong> Those template-file changes are included in the &quot;base&quot; Zen Cart distribution, starting with v1.5.6!</p>
                         <p>In all cases, the changes that <em>IH<sup>5</sup></em> requires are additions of Zen Cart &quot;notifiers&quot; to allow <em>IH<sup>5</sup></em> to do its job in a seamless manner.  The changes required <b>do not affect the functionality</b> of the modules and can be left safely in place if you decide to uninstall <em>Image Handler</em>.</p>
@@ -579,19 +579,22 @@
                     <fieldset>
                         <legend>Image Handler<sup>5</sup></legend>
                         <ul>
-                            <li>v5.0.1, 2018-01-xx:<ul>
+                            <li>v5.0.1, 2018-05-xx:<ul>
                                 <li>CHANGE: Added <em>View Image Handler Configuration</em> to the <em>IH</em><sup>5</sup> admin menu.</li>
                                 <li>CHANGE: Removed <em>Scan for old images</em> tool from the <em>IH</em><sup>5</sup> admin menu.</li>
                                 <li>BUGFIX: Invalid &quot;quality&quot; parameter supplied to <code>imagepng</code>, resulting in oversized images being created.</li>
                                 <li>CHANGE: Move <em>Image Handler</em><sup>5</sup> help-text to a separate language file.</li>
                                 <li>BUGFIX: Background checker not recognizing &quot;transparent&quot; (with no RGB) as a valid setting.</li>
+                                <li>BUGFIX: Notifiers in the additional- and main-product-image modules need to be &quot;globalized&quot;.</li>
                                 <li>The following files were changed (all in the <em>1_Installation_Files (v1.5.5)</em> directory):<ol>
                                     <li>/includes/classes/bmz_image_handler.class.php</li>
                                     <li>/includes/functions/extra_functions/functions_bmz_image_handler.php</li>
+                                    <li>/includes/modules/YOUR_TEMPLATE/additional_images.php</li>
+                                    <li>/includes/modules/YOUR_TEMPLATE/main_product_image.php</li>
                                     <li>/YOUR_ADMIN/image_handler.php</li>
                                     <li>/YOUR_ADMIN/image_handler_uninstall.php</li>
                                     <li>/YOUR_ADMIN/image_handler_view_config.php <span class="smaller">(Added)</span></li>
-                                    <li>/YOUR_ADMIN/ih_manager.php</li>
+                                    <li>/YOUR_ADMIN/includes/ih_manager.php</li>
                                     <li>/YOUR_ADMIN/includes/classes/ImageHandlerAdmin.php</li>
                                     <li>/YOUR_ADMIN/includes/extra_datafiles/image_handler.php</li>
                                     <li>/YOUR_ADMIN/includes/init_includes/init_image_handler.php</li>


### PR DESCRIPTION
Globalize the use of the $zco_notifier and bring the additional images' module to be "in line" with the Zen Cart 1.5.6 base.