### PR TITLE
#118-globalize-template-dir-for-colorbox

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/classes/observers/ColorBoxObserver.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/observers/ColorBoxObserver.php
@@ -33,6 +33,7 @@ class ColorBoxObserver extends base
             //                     the default module's processing is bypassed.
             //
             case 'NOTIFY_MODULES_ADDITIONAL_IMAGES_SCRIPT_LINK':
+                global $template_dir;
                 $flag_display_large = $p1['flag_display_large'];
                 $products_name = $p1['products_name'];
                 $products_image_large = $p1['products_image_large'];


### PR DESCRIPTION
The `ColorBox` extra_function file needs global access to the $template_dir variable.