### PR TITLE
#110-migrate-readme-to-markdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 .gitattributes    export-ignore
 *.yml             export-ignore
 README.md         export-ignore
+/readme           export-ignore

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Image Handler v5.0.0
+# Image Handler v5.1.0
 
 The latest released version is available for download from the Zen Cart site, via [this](https://www.zen-cart.com/downloads.php?do=file&id=2169) link.  If you need basic installation help, and neither this information nor the included readme does not help you, please visit the [Image Handler v5.x Support Thread](https://www.zen-cart.com/showthread.php?222983)
 


### PR DESCRIPTION
Update the .gitattributes so the /readme directory is still available but not part of the distribution zip-file; update version in base readme to 5.1.0.