### PR TITLE
#129-dir-fs-catalog-root-correction

### DIFF
--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
@@ -7,7 +7,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-define('IH_CURRENT_VERSION', '5.1.0');
+define('IH_CURRENT_VERSION', '5.1.1-beta1');
 
 // -----
 // Wait until an admin is logged in before seeing if any initialization steps need to be performed.

--- a/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
@@ -12,6 +12,7 @@
  * Modified by lat9: 2017-07-17, correcting class constructor name, applying PSR-2 formatting.
  * Modified by lat9: 2018-05-19, various refinements (see GitHub #106).
  * Modified by lat9: 2018-05-20, Remove handling for mixed-case file extensions from file_not_found method (see GitHub #89)
+ * Modified by lat9: 2018-06-04, Correction for DIR_FS_CATALOG set to '/'.
  */
  
 if (!defined('IH_DEBUG_ADMIN')) {
@@ -353,7 +354,11 @@ class ih_image
             if (($local_mtime > $file_mtime || $local_mtime > $watermark_mtime || $local_mtime > $zoom_mtime) ||
                 $this->resize_imageIM($file_extension, $local, $background, $quality) ||
                 $this->resize_imageGD($file_extension, $local, $background, $quality) ) {
-                $return_file = str_replace($ihConf['dir']['docroot'], '', $local);
+                if (strpos($local, $ihConf['dir']['docroot']) !== 0) {
+                    $return_file = $local;
+                } else {
+                    $return_file = substr($local, strlen($ihConf['dir']['docroot']));
+                }
                 $this->ihLog("... returning $return_file");
                 return $return_file;
             }

--- a/docs/image_handler/readme.html
+++ b/docs/image_handler/readme.html
@@ -62,7 +62,7 @@ th { background-color: #eee; }
 
 <body>
   <h1>Image Handler<sup>5</sup> for Zen Cart v1.5.5 (and later)</h1>
-  <h3>Version 5.1.0 by lat9</h3>
+  <h3>Version 5.1.1 by lat9</h3>
   <p>Current Support Thread at Zen Cart Forums: <a href=="https://www.zen-cart.com/showthread.php?222983-Image-Handler-5-(for-v1-5-5)-Support-Thread">https://www.zen-cart.com/showthread.php?222983-Image-Handler-5-(for-v1-5-5)-Support-Thread</a></p>
   
   <p><strong>Notes:</strong></p>
@@ -411,6 +411,13 @@ th { background-color: #eee; }
             
             <div id="changes">
                 <ul>
+                    <li>v5.1.1, 2018-06-xx:<ul>
+                        <li>BUGFIX: Correct 'bmz_cache' file location when DIR_FS_LOGS is set to '/'.</li>
+                        <li>The following files were changed (all in the <em>1_Installation_Files (v1.5.5)</em> directory):<ol>
+                            <li>/includes/classes/bmz_image_handler.class.php</li>
+                            <li>/YOUR_ADMIN/includes/init_includes/init_image_handler.php</li>
+                        </ol></li>
+                    </ul></li>
                     <li>v5.1.0, 2018-05-29:<ul>
                         <li>CHANGE: Added <em>View Image Handler Configuration</em> to the <em>IH</em><sup>5</sup> admin menu.</li>
                         <li>CHANGE: Removed <em>Scan for old images</em> tool from the <em>IH</em><sup>5</sup> admin menu.</li>


### PR DESCRIPTION
Strip the leading 'image-directory' from the image's name, if present.  Corrects the issue where DIR_FS_CATALOG is set to '/'.