### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
+++ b/1_Installation_Files (v1.5.5)/includes/modules/YOUR_TEMPLATE/additional_images.php
@@ -84,7 +84,7 @@ if ($products_image != '' && $flag_show_product_info_additional_images != 0) {
     }
 }
 
-$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', NULL, $images_array);
+$GLOBALS['zco_notifier']->notify('NOTIFY_MODULES_ADDITIONAL_PRODUCT_IMAGES_LIST', null, $images_array);
 
 
 // Build output based on images found


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!