### PR TITLE
#182: More CSS buttons

### DIFF
--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/image_handler.php
@@ -316,13 +316,13 @@ if ($ih_page == 'manager') {
             <td class="ih-center"><?php echo zen_draw_products_pull_down('products_filter', 'size="5"', '', true, $products_filter, true, true); ?></td>
             <td id="ih-p-buttons" class="ih-center ih-vtop">
 <?php 
-        echo '<input  type="submit" class="btn btn-primary" value="'. IMAGE_DISPLAY .'" ><br />';
+        echo '<input type="submit" class="btn btn-primary" value="'. IMAGE_DISPLAY .'" />&nbsp;';
 	
         $edit_product_link = zen_href_link(FILENAME_PRODUCT, "action=new_product&amp;cPath=$current_category_id&amp;pID=$products_filter&amp;product_type=" . zen_get_products_type($products_filter));
-        echo '<a href="' . $edit_product_link . '" class="btn btn-info">' . IMAGE_EDIT_PRODUCT . '</a><br />';
+        echo '<a href="' . $edit_product_link . '" class="btn btn-info">' . IMAGE_EDIT_PRODUCT . '</a>&nbsp;';
         
         $attribute_controller_link = zen_href_link(FILENAME_ATTRIBUTES_CONTROLLER, "products_filter=$products_filter&amp;current_category_id=$current_category_id");
-        echo '<a href="' . $attribute_controller_link . '"class="btn btn-warning">' . IMAGE_EDIT_ATTRIBUTES . '</a>'
+        echo '<a href="' . $attribute_controller_link . '" class="btn btn-warning">' . IMAGE_EDIT_ATTRIBUTES . '</a>'
 ?>
             </td>
 <?php

--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/image_handler_uninstall.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/image_handler_uninstall.php
@@ -180,7 +180,7 @@ if (!isset($_POST['action']) || $_POST['action'] != 'confirm') {
         <tr>
             <td><?php echo zen_draw_form('remove', FILENAME_IMAGE_HANDLER_UNINSTALL) . zen_draw_hidden_field('action', $next_action);?>
                 <p><?php echo $current_message; ?></p>
-                <p><a href="<?php echo zen_href_link(FILENAME_DEFAULT); ?>"><?php echo zen_image_button('button_cancel.gif', IMAGE_CANCEL); ?></a>&nbsp;&nbsp;<?php echo zen_image_submit('button_go.gif', IMAGE_GO); ?></p>
+                <p><a href="<?php echo zen_href_link(FILENAME_DEFAULT); ?>" class="btn btn-warning"><?php echo IMAGE_CANCEL; ?></a>&nbsp;&nbsp;<input type="submit" class="btn btn-danger" value="<?php echo IMAGE_GO; ?>" /></p>
             </form></td>
         </tr>
     </table></td>


### PR DESCRIPTION
- Use CSS buttons for the IH 'uninstall' script.
- In the main IH page, put 'Display', 'Edit Product' and 'Edit Attributes' on a single line, instead of stacked.