### PR TITLE
Modification to Unhashed issue #72 created Mirrored as additional option

### DIFF
--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
@@ -261,7 +261,7 @@ if (isset($_SESSION['admin_id'])) {
             zen_register_admin_page('toolsImageHandlerUninstall', 'BOX_TOOLS_IMAGE_HANDLER_UNINSTALL', 'FILENAME_IMAGE_HANDLER_UNINSTALL', '', 'tools', 'N', 99);
         }
         
-        if (version_compare(IH_VERSION, '5.0.0', '<') || !defined('IH_CACHE_NAMING')) {
+        if (version_compare(IH_VERSION, '5.0.0', '<')) {
             if (!defined('IH_CACHE_NAMING')) {
                 if (IH_VERSION == '0.0.0' || version_compare(IH_VERSION, '4.3.3', '>')) {
                     $default = 'Readable';
@@ -275,14 +275,6 @@ if (isset($_SESSION['admin_id'])) {
                         ( 'Cache File-naming Convention', 'IH_CACHE_NAMING', '$default', 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.<br /><br />Image Handler v5.1.9 introduced <em>Mirrored</em> which is the same as readable but it creates a directory structure under bmz_cache that mirrors the directory structure where the original images are saved.', $cgi, 1006, now(), NULL, 'zen_cfg_select_option(array(\'Hashed\', \'Mirrored\', \'Readable\'),')"
                 );
             }
-        } elseif (version_compare(IH_VERSION, '5.1.9', '<')) {
-            $db->Execute(
-                "UPDATE " . TABLE_CONFIGURATION . "
-                     SET configuration_description = 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.<br /><br />Image Handler v5.1.9 introduced <em>Mirrored</em> which is the same as readable but it creates a directory structure under bmz_cache that mirrors the directory structure where the original images are saved.',
-                         set_function = 'zen_cfg_select_option(array(\'Hashed\', \'Mirrored\', \'Readable\'),'
-                     WHERE configuration_key = 'IH_CACHE_NAMING'"
-                );
-            
         }
         
         if (version_compare(IH_VERSION, '5.1.0', '<')) {
@@ -290,7 +282,7 @@ if (isset($_SESSION['admin_id'])) {
                 zen_register_admin_page('toolsImageHandlerViewConfig', 'BOX_TOOLS_IMAGE_HANDLER_VIEW_CONFIG', 'FILENAME_IMAGE_HANDLER_VIEW_CONFIG', '', 'tools', 'N', 99);
             }
         }
-        
+               
         // -----
         // v5.1.2:
         // - GitHub#147: Correct configuration description for the three background settings, changing -transparent- to <b>transparent</b>.
@@ -301,6 +293,20 @@ if (isset($_SESSION['admin_id'])) {
                     SET configuration_description = 'If converted from an uploaded image with transparent areas, these areas become the specified color. Set to <b>transparent</b> to keep transparency.'
                   WHERE configuration_key IN ('SMALL_IMAGE_BACKGROUND', 'MEDIUM_IMAGE_BACKGROUND', 'LARGE_IMAGE_BACKGROUND')"
             );
+        }
+       
+        // -----
+        // v5.1.9
+        // - GitHub#72: Add mirrored to IH_CACHE_NAMING to mirror the base directory structure
+        //
+         if (version_compare(IH_VERSION, '5.1.9', '<')) {
+            $db->Execute(
+                "UPDATE " . TABLE_CONFIGURATION . "
+                     SET configuration_description = 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.<br /><br />Image Handler v5.1.9 introduced <em>Mirrored</em> which is the same as readable but it creates a directory structure under bmz_cache that mirrors the directory structure where the original images are saved.',
+                         set_function = 'zen_cfg_select_option(array(\'Hashed\', \'Mirrored\', \'Readable\'),'
+                     WHERE configuration_key = 'IH_CACHE_NAMING'"
+                );
+            
         }
         
         $db->Execute(

--- a/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
+++ b/1_Installation_Files (v1.5.5)/YOUR_ADMIN/includes/init_includes/init_image_handler.php
@@ -261,7 +261,7 @@ if (isset($_SESSION['admin_id'])) {
             zen_register_admin_page('toolsImageHandlerUninstall', 'BOX_TOOLS_IMAGE_HANDLER_UNINSTALL', 'FILENAME_IMAGE_HANDLER_UNINSTALL', '', 'tools', 'N', 99);
         }
         
-        if (version_compare(IH_VERSION, '5.0.0', '<')) {
+        if (version_compare(IH_VERSION, '5.0.0', '<') || !defined('IH_CACHE_NAMING')) {
             if (!defined('IH_CACHE_NAMING')) {
                 if (IH_VERSION == '0.0.0' || version_compare(IH_VERSION, '4.3.3', '>')) {
                     $default = 'Readable';
@@ -272,9 +272,17 @@ if (isset($_SESSION['admin_id'])) {
                     "INSERT INTO " . TABLE_CONFIGURATION . " 
                         ( configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added, use_function, set_function ) 
                      VALUES 
-                        ( 'Cache File-naming Convention', 'IH_CACHE_NAMING', '$default', 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.', $cgi, 1006, now(), NULL, 'zen_cfg_select_option(array(\'Hashed\', \'Readable\'),')"
+                        ( 'Cache File-naming Convention', 'IH_CACHE_NAMING', '$default', 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.<br /><br />Image Handler v5.1.9 introduced <em>Mirrored</em> which is the same as readable but it creates a directory structure under bmz_cache that mirrors the directory structure where the original images are saved.', $cgi, 1006, now(), NULL, 'zen_cfg_select_option(array(\'Hashed\', \'Mirrored\', \'Readable\'),')"
                 );
             }
+        } elseif (version_compare(IH_VERSION, '5.1.9', '<')) {
+            $db->Execute(
+                "UPDATE " . TABLE_CONFIGURATION . "
+                     SET configuration_description = 'Choose the method that <em>Image Handler</em> uses to name the resized images in the <code>bmz_cache</code> directory.<br /><br />The <em>Hashed</em> method was used by Image Handler versions prior to 4.3.4 and uses an &quot;MD5&quot; hash to produce the filenames.  It can be &quot;difficult&quot; to visually identify the original file using this method.  If you are upgrading Image Handler from a version prior to 4.3.4 <em>and</em> you have hard-coded links in product (or other) definitions to those images, <b>do not change</b> this setting from <em>Hashed</em>.<br /><br />Image Handler v4.3.4 (unreleased) introduced the concept of a <em>Readable</em> name for those resized images.  This is a good choice for new installations of <em>IH</em> or for upgraded installations that do not have hard-coded image links.<br /><br />Image Handler v5.1.9 introduced <em>Mirrored</em> which is the same as readable but it creates a directory structure under bmz_cache that mirrors the directory structure where the original images are saved.',
+                         set_function = 'zen_cfg_select_option(array(\'Hashed\', \'Mirrored\', \'Readable\'),'
+                     WHERE configuration_key = 'IH_CACHE_NAMING'"
+                );
+            
         }
         
         if (version_compare(IH_VERSION, '5.1.0', '<')) {

--- a/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
@@ -340,7 +340,7 @@ class ih_image
                 case 'Hashed':
                     $local = $this->getCacheName($this->src . $this->watermark['file'] . $this->zoom['file'] . $quality . $background . $ihConf['watermark']['gravity'], '.image.' . $newwidth . 'x' . $newheight . $file_extension);
                     break;
-                case'Mirrored':
+                case 'Mirrored':
                     // use pathinfo to get full path of an image
                     $image_path = pathinfo($this->src);
                     // get image name from path and clean it up for those who don't know how image files SHOULD be named
@@ -355,6 +355,7 @@ class ih_image
                     // and now do the magic and create cached image name with the above parameters
                     $local = $this->getCacheName(strtolower($image_dir . $image_basename), '.image.' . $newwidth . 'x' . $newheight . $file_extension);
                     break;
+                case 'Readable':
                 default:
                     // use pathinfo to get full path of an image
                     $image_path = pathinfo($this->src);
@@ -439,6 +440,7 @@ class ih_image
             // Use readable file name and place in mirror of original directory
                 $file = $GLOBALS['bmzConf']['cachedir'] . '/' . $data . $ext;
                 break;
+            case 'Readable':
             default:
             // Use readable file name and place directory using first character of $data
                 $file = $GLOBALS['bmzConf']['cachedir'] . '/' . substr($data, 0, 1) . '/' . $data . $ext;

--- a/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
@@ -13,6 +13,7 @@
  * Modified by lat9: 2018-05-19, various refinements (see GitHub #106).
  * Modified by lat9: 2018-05-20, Remove handling for mixed-case file extensions from file_not_found method (see GitHub #89)
  * Modified by lat9: 2018-06-04, Correction for DIR_FS_CATALOG set to '/'.
+ * Modified by brittainmark: 2020-10-18, Add Mirrored to mirror original directory structure (see GitHub #72)
  */
  
 if (!defined('IH_DEBUG_ADMIN')) {
@@ -335,27 +336,45 @@ class ih_image
         
         // Do we need to resize, watermark, zoom or convert to another filetype?
         if ($this->file_exists && ($resize || $this->watermark['file'] != '' || $this->zoom['file'] != '' || $file_extension != $this->extension)) {
-            if (IH_CACHE_NAMING == 'Hashed') {
-                $local = $this->getCacheName($this->src . $this->watermark['file'] . $this->zoom['file'] . $quality . $background . $ihConf['watermark']['gravity'], '.image.' . $newwidth . 'x' . $newheight . $file_extension);
-            } else {
-                // use pathinfo to get full path of an image
-                $image_path = pathinfo($this->src);
+            switch (IH_CACHE_NAMING) {
+                case 'Hashed':
+                    $local = $this->getCacheName($this->src . $this->watermark['file'] . $this->zoom['file'] . $quality . $background . $ihConf['watermark']['gravity'], '.image.' . $newwidth . 'x' . $newheight . $file_extension);
+                    break;
+                case'Mirrored':
+                    // use pathinfo to get full path of an image
+                    $image_path = pathinfo($this->src);
+                    // get image name from path and clean it up for those who don't know how image files SHOULD be named
+                    $image_basename = $this->sanitizeImageNames($image_path['basename']);
+                    $image_dirname = ($image_path['dirname']);
+                    // Remove Images default directory from path
+                    if ($image_dirname == rtrim(DIR_WS_IMAGES, '/')) {
+                        $image_dir = '';
+                    } else {
+                        $image_dir = substr($image_path['dirname'],strlen(DIR_WS_IMAGES)) . '/';
+                    }
+                    // and now do the magic and create cached image name with the above parameters
+                    $local = $this->getCacheName(strtolower($image_dir . $image_basename), '.image.' . $newwidth . 'x' . $newheight . $file_extension);
+                    break;
+                default:
+                    // use pathinfo to get full path of an image
+                    $image_path = pathinfo($this->src);
                 
-                // get image name from path and clean it up for those who don't know how image files SHOULD be named
-                $image_basename = $this->sanitizeImageNames($image_path['basename']);
-                
-                // get last directory from path and clean that up just like the image's base name
-                $image_dirname = $this->sanitizeImageNames(basename($image_path['dirname']));
-                
-                // if last directory is images (meaning image is stored in main images folder), do nothing, else append directory name
-                if ($image_dirname == rtrim(DIR_WS_IMAGES, '/')) {
-                    $image_dir = '';
-                } else {
-                    $image_dir = $image_dirname . '-';
-                }
-                
-                // and now do the magic and create cached image name with the above parameters
-                $local = $this->getCacheName(strtolower($image_dir . $image_basename), '.image.' . $newwidth . 'x' . $newheight . $file_extension);
+                    // get image name from path and clean it up for those who don't know how image files SHOULD be named
+                    $image_basename = $this->sanitizeImageNames($image_path['basename']);
+              
+                    // get last directory from path and clean that up just like the image's base name
+                    $image_dirname = $this->sanitizeImageNames(basename($image_path['dirname']));
+        
+                    // if last directory is images (meaning image is stored in main images folder), do nothing, else append directory name
+                    if ($image_dirname == rtrim(DIR_WS_IMAGES, '/')) {
+                       $image_dir = '';
+                    } else {
+                        $image_dir = $image_dirname . '-';
+                    }
+                                   
+                    // and now do the magic and create cached image name with the above parameters
+                    $local = $this->getCacheName(strtolower($image_dir . $image_basename), '.image.' . $newwidth . 'x' . $newheight . $file_extension);
+                    break;
             }
             
             //echo $local . '<br />';    
@@ -410,8 +429,21 @@ class ih_image
     //-NOTE: This function was (for versions prior to 5.0.1) present in /includes/functions/extra_functions/functions_bmz_io.php
     protected function getCacheName($data, $ext='') 
     {
-        $md5  = (IH_CACHE_NAMING == 'Hashed') ? md5($data) : $data;
-        $file = $GLOBALS['bmzConf']['cachedir'] . '/' . substr($md5, 0, 1) . '/' . $md5 . $ext;
+        switch (IH_CACHE_NAMING) {
+            case 'Hashed':
+            // Hash the name and place in directory using first character of hashed string
+                $md5 = md5($data);
+                $file = $GLOBALS['bmzConf']['cachedir'] . '/' . substr($md5, 0, 1) . '/' . $md5 . $ext;
+                break;
+            case 'Mirrored':
+            // Use readable file name and place in mirror of original directory
+                $file = $GLOBALS['bmzConf']['cachedir'] . '/' . $data . $ext;
+                break;
+            default:
+            // Use readable file name and place directory using first character of $data
+                $file = $GLOBALS['bmzConf']['cachedir'] . '/' . substr($data, 0, 1) . '/' . $data . $ext;
+                break;
+            }
         io_makeFileDir($file);
         $this->ihLog("getCacheName($data, $ext), returning $file.");
         return $file;

--- a/pages/c_cache.md
+++ b/pages/c_cache.md
@@ -1,15 +1,22 @@
 [Back](configuration.md "Return to the Configuration page")
 # Cache File-Naming Conventions
-Starting with IH<sup>5</sup>, you can choose the naming convention used for re-sized files created by the image-handler, one of _Hashed_ or _Readable_.
+Starting with IH<sup>5</sup>, you can choose the naming convention used for re-sized files created by the image-handler, one of _Hashed_,  _Readable_ or _Mirrored_.
 
 ## Hashed
 
-This is the convention used by image-handler versions prior to 4.3.4. The handler uses an MD5 hash to compress the resized file's original path, name and parameters to produce file names similar to `8240eb50da20af3ecec990d3e56099fa.image.50x40.gif`. It can be "very difficult" to determine which original file is associated with that resized file!.
+This is the convention used by image-handler versions prior to 4.3.4. The handler uses an MD5 hash to compress the resized file's original path, name and parameters to produce file names similar to `8240eb50da20af3ecec990d3e56099fa.image.50x40.gif` in the directory `bmz_cache\8`. It can be "very difficult" to determine which original file is associated with that resized file!.
 
 If you are currently using an Image Handler version prior to 4.3.4, this naming-convention will be initially configured on your IH upgrade. Some stores use HTML `img` tags in their category and/or product descriptions that reference an image's "hashed" name and this default is set to ensure that downward compatibility.
 
 ## Readable
 
-This is the convention introduced image-handler versions later than 4.3.3. The handler concatenates the original file's path, name and parameters to produce file names similar to `matrox-mg400-32mbgif.image.50x40`. It's a little easier to determine which original file is associated with that resized filename!
+This is the convention introduced image-handler versions later than 4.3.3. The handler concatenates the original file's path, name and parameters to produce file names similar to `matrox-mg400-32mbgif.image.50x40` in the directory `bmz_cache\m`. It's a little easier to determine which original file is associated with that resized filename!
 
 If you are performing an initial install or upgrading Image Handler from a version later than 4.3.3, this naming will be initially configured for your IH<sup>5</sup> installation.
+
+## Mirrored
+
+This is a convention introduced with image-handler version 5.1.9. The handler concatenates the original name and parameters to produce file names similar to  _Readable_.  The difference is that instead of storing the files under a single letter directory (the first character of the file name), The files are stored in a mirror of the original directory structure. This is useful if you have many images that start with the same letter allowing them to be spread through directories as the original files.
+
+For example:
+If you have a file called `matrox.gif` in the directory `images\Graphics\cards` You would create a file like `matrox-mg400-32mbgif.image.50x40.gif` in the directory `bmz_cache\Graphics\cards`


### PR DESCRIPTION
I have modified the code and the docs to add a new option Mirrored that mirrors the original directory structure under bmz_cache and uses the readable file names.

This is as discussed in issue number 72. I have changed it a bit since then to use switch case for each of the three cases I have readable as the default.

I have tested on zen cart version 1.5.6c using php 7.4

Hope acceptable.