### PR TITLE
bmz_image_handler.class.php casting in calculate_gravity

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
@@ -880,9 +880,11 @@ class ih_image
      */
     protected function calculate_gravity($canvaswidth, $canvasheight, $overlaywidth, $overlayheight, $gravity)
     {
+        $canvaswidth = (int)$canvaswidth;
+        $canvasheight = (int)$canvasheight;
         // Calculate overlay position from gravity setting. Center as default.
-        $startheight = (int)($canvasheight - $overlayheight) / 2;
-        $startwidth = (int)($canvaswidth - $overlaywidth) / 2;
+        $startheight = (int)(($canvasheight - $overlayheight) / 2);
+        $startwidth = (int)(($canvaswidth - $overlaywidth) / 2);
         if (strpos($gravity, 'North') !== false) {
             $startheight = 0;
         } elseif (strpos($gravity, 'South') !== false) {


### PR DESCRIPTION
php8, strict reporting

> PHP Fatal error:  Uncaught TypeError: imagecopy(): Argument #3 ($dst_x) must be of type int, float given in includes\classes\bmz_image_handler.class.php:798

in calculate_gravity, this sometimes returns a float as the int is only on the subtraction, not the division.
```
$startheight = (int)($canvasheight - $overlayheight) / 2;
$startwidth = (int)($canvaswidth - $overlaywidth) / 2;
```
so subsequently this gets to imagecopy