### PR TITLE
handle corrupt file

### DIFF
--- a/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
+++ b/1_Installation_Files (v1.5.5)/includes/classes/bmz_image_handler.class.php
@@ -477,7 +477,12 @@ class ih_image
      */
     public function calculate_size($pref_width, $pref_height = '')
     {
-        if (file_exists($this->filename)) {
+        if (is_file($this->filename)) {
+            $image_info = @getimagesize($this->filename);//silence multiple default error messages
+            if ($image_info === false){
+                trigger_error("Image Handler, calculate_size($this->filename) returned FALSE: image is corrupt");
+                $this->filename = DIR_WS_IMAGES . PRODUCTS_IMAGE_NO_IMAGE;
+            }
             list($width, $height) = getimagesize($this->filename);
             $this->ihLog("calculate_size($pref_width, $pref_height), getimagesize returned $width x $height.");
         } else {


### PR DESCRIPTION
An uploaded image somehow was empty, with a filesize of zero. It was not caught by other checks until IH tried getimagesize.

getimagesize returns false on error but by default also produces multiple notices that are pretty confusing.
I decided to silence it and issue a more informative message, and replace the defective file reference with the default missing image.
This can be tested by opening an image file in notepad and deleting all content.
