### PR TITLE
Detect, and use, the type of image file; prevents issues when file renamed to an improper extension

### DIFF
--- a/includes/classes/bmz_image_handler.class.php
+++ b/includes/classes/bmz_image_handler.class.php
@@ -49,7 +49,8 @@ class ih_image
         $sizetype,
         $src,           // reference to an actual physical image
         $watermark,
-        $width;
+        $width,
+        $image_type;    // the actual type of the image supplied
 
     /**
      * ih_image class constructor
@@ -505,7 +506,7 @@ class ih_image
                 $this->filename = DIR_WS_IMAGES . PRODUCTS_IMAGE_NO_IMAGE;
                 $image_info = getimagesize($this->filename);
             }
-            list($width, $height) = $image_info;
+            list($width, $height, $this->image_type) = $image_info;
             $this->ihLog("calculate_size: file " . $this->filename . " ($pref_width, $pref_height), getimagesize returned $width x $height.");
         } else {
             $this->ihLog('calculate_size: file "' . $this->filename . '" does NOT exist.');
@@ -927,25 +928,24 @@ class ih_image
      *
      * @return false|GdImage|mixed|resource
      */
-    protected function load_imageGD($src_name)
+    protected function load_imageGD($src_name,$retry = false)
     {
         // create an image of the given filetype
-        $file_ext = '.' . pathinfo($src_name, PATHINFO_EXTENSION);
-        switch (strtolower($file_ext)) {
-            case '.gif':
+        
+        switch ($this->image_type) {
+            case IMAGETYPE_GIF:
                 if (!function_exists('imagecreatefromgif')) {
                     return false;
                 }
                 $image = imagecreatefromgif($src_name);
                 break;
-            case '.png':
+            case IMAGETYPE_PNG:
                 if (!function_exists('imagecreatefrompng')) {
                     return false;
                 }
                 $image = imagecreatefrompng($src_name);
                 break;
-            case '.jpg':
-            case '.jpeg':
+            case IMAGETYPE_JPEG:
                 if (!function_exists('imagecreatefromjpeg')) {
                     return false;
                 }


### PR DESCRIPTION
fixes #19 and [forum issue](https://www.zen-cart.com/showthread.php?222983-Image-Handler-5-(for-v1-5-5-v1-5-8)-Support-Thread&p=1392819#post1392819)
Use image info returned by getimagesize in function calculate_size to determine the type of image to use in the function load_imageGD

